### PR TITLE
Provide functionality for extension to swap between before and after pages

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,8 @@
+// listen for sendMessage() from content script
+browser.runtime.onMessage.addListener(
+    function (request, sender, sendResponse) {
+        // disable browser action for the current tab
+        browser.browserAction.disable(sender.tab.id);
+        console.log(`URL hit: ${request.url}`);
+    }
+);

--- a/content.js
+++ b/content.js
@@ -1,0 +1,8 @@
+// get the URL of the page
+var url = document.location.href;
+
+// if not on demo site domain
+if (url.indexOf("de4a11y-bad-site-demo.azurewebsites.net") === -1) {
+    // send anything we want to change, like "disabled" appropriate icons. ATM nothing!
+    browser.runtime.sendMessage({"url": url});
+}

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,18 @@
     "browser_action": {
         "default_title": "Eye for A11y",
         "default_popup": "popup.html"
+    },
+    "content_scripts": [
+        {
+            "matches": [
+                "<all_urls>"
+            ],
+            "js": [ "content.js" ],
+            "run_at": "document_end"
+        }
+    ],
+    "background": {
+        "scripts": [ "background.js" ],
+        "persistent": true
     }
 }

--- a/popup.html
+++ b/popup.html
@@ -5,6 +5,9 @@
 </head>
 <body>
     <h1>Eye for A11y</h1>
-    <a href="https://garagehackbox.azurewebsites.net/hackathons/1214/projects/70460">More Info</a>
+    <button id="swapPageContent">Improve accessibility</button>
+    <button id="resetToOriginal" disabled="disabled">Reset</button>
+    <a id="moreInfoLink"href="https://garagehackbox.azurewebsites.net/hackathons/1214/projects/70460">More Info</a>
+    <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,14 @@
+let swap = document.getElementById('swapPageContent');
+let reset = document.getElementById('resetToOriginal');
+
+swap.onclick = function () {
+    swap.disabled = true;
+    reset.disabled = false;
+    browser.tabs.update({ url: "https://de4a11y-bad-site-demo.azurewebsites.net/after.html" });
+}
+
+reset.onclick = function () {
+    swap.disabled = false;
+    reset.disabled = true;
+    browser.tabs.update({ url: "https://de4a11y-bad-site-demo.azurewebsites.net/before.html" });
+}

--- a/style.css
+++ b/style.css
@@ -6,9 +6,38 @@
 h1 {
     font-weight: 600;
     font-size: .9em;
+    grid-column: 1;
+    grid-row: 1;
+    text-align: center;
 }
 
 a {
     font-weight: 600;
     font-size: .8em;
+}
+
+body {
+    display: grid;
+    grid-row-gap: 10px;
+    grid-column-gap: 5px;
+    height: 200px;
+    width: 200px;
+}
+
+#swapPageContent, #resetToOriginal {
+    grid-column: 1;
+    font-size: 12px;
+}
+
+#swapPageContent {
+    grid-row: 2;
+}
+
+#resetToOriginal {
+    grid-row: 3;
+}
+
+#moreInfoLink {
+    grid-column: 1;
+    grid-row: 4;
 }


### PR DESCRIPTION
The extension now provides two buttons that swap the pages and swap them back again respectively. 

Also, the extension is now only enabled on sites on our test site domain (well also some other pages like new tab page, seems like it will take more unnecessary work to exclude these). I thought this might be a good idea because right now our extension is quite limited in terms of the cases it can work with, and our model may work well only with some sites to begin with, which we can easily add for.

Also, I adjusted the layout of the UI for the Pop up of the extension.
